### PR TITLE
Don't double-eval quoted params (fixes #13)

### DIFF
--- a/customblocks/customblocks.py
+++ b/customblocks/customblocks.py
@@ -119,7 +119,7 @@ class CustomBlocksProcessor(BlockProcessor):
         for key, param in self.RE_PARAM.findall(params):
             if param[0] == param[-1] == '"':
                 param = eval(param)
-            if param[0] == param[-1] == "'":
+            elif param[0] == param[-1] == "'":
                 param = eval(param)
             if key:
                 kwd[key] = param

--- a/customblocks/customblocks_test.py
+++ b/customblocks/customblocks_test.py
@@ -395,6 +395,27 @@ class CustomBlockExtension_Test(test_tools.TestCase):
             <custom key="value"></custom>
             """)
 
+    def test_customGenerator_keyword_eval(self):
+        def custom(ctx, key):
+            div = etree.SubElement(ctx.parent, 'custom')
+            div.set('key', key)
+
+        self.setupCustomBlocks(custom=custom)
+
+        self.assertMarkdown("""\
+            ::: custom key=''
+            """,
+            """\
+            <custom key=""></custom>
+            """)
+
+        self.assertMarkdown("""\
+            ::: custom key=""
+            """,
+            """\
+            <custom key=""></custom>
+            """)
+
     def test_customGenerator_positional(self):
         def custom(ctx, key):
             div = etree.SubElement(ctx.parent, 'custom')


### PR DESCRIPTION
Because the code redefines `param`, without the elif here this block can run on an empty param string, incorrectly running `eval` twice:
```py
            elif param[0] == param[-1] == "'":
                param = eval(param)
```
This patch fixes the bug. 